### PR TITLE
Group Dependabot and document protected main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## Summary
+-
+
+## Test plan
+-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,35 @@ updates:
     directory: /cadence
     schedule:
       interval: weekly
+    open-pull-requests-limit: 1
+    groups:
+      python:
+        patterns:
+          - "*"
   - package-ecosystem: npm
     directory: /front
     schedule:
       interval: weekly
+    open-pull-requests-limit: 1
+    groups:
+      javascript:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 1
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,8 +79,16 @@ If a change affects migrations, API behavior, or configuration, include the
 relevant test coverage and explain any manual verification in the pull
 request.
 
+## Branches
+
+Open a pull request against `main`. Name the branch after the change, for
+example `fix/habit-checkbox` or `chore/ci`. GitHub Dependabot opens its own
+`dependabot/...` branches for package updates; those are not a model for
+feature work.
+
 ## Pull requests
 
 Describe what changed, why it changed, and how it was tested. Keep unrelated
 cleanup out of feature changes, and update documentation when setup or
-behavior changes.
+behavior changes. `main` is protected: changes go through a pull request,
+and CI must pass before merge.


### PR DESCRIPTION
## Summary
- Group weekly Dependabot updates into one PR per ecosystem so GitHub does not open a branch per package.
- Add a short pull request template and branch-naming notes for contributors.

## Test plan
- [ ] Confirm Dependabot config is valid after merge (GitHub Dependabot tab).
- [ ] Confirm the PR template appears on the next pull request.