### PR TITLE
Make Cadence usable on a phone

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Cadence: habits, hours, focus</title>
     <script>
       try {

--- a/front/src/components/ContinuityExplorer.tsx
+++ b/front/src/components/ContinuityExplorer.tsx
@@ -67,7 +67,7 @@ export default function ContinuityExplorer({
         <div
           role="tablist"
           aria-label="History views"
-          className="cadence-rail flex gap-5 pb-2"
+          className="cadence-rail flex flex-wrap gap-x-3 gap-y-1 pb-2"
         >
           {views.map((item) => (
             <button
@@ -82,8 +82,8 @@ export default function ContinuityExplorer({
               onKeyDown={(event) => handleTabKey(event, item.id)}
               className={
                 view === item.id
-                  ? "text-sm text-violet-300"
-                  : "text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-300"
+                  ? "min-h-11 px-1 text-sm text-violet-300"
+                  : "min-h-11 px-1 text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-300"
               }
             >
               {item.label}
@@ -96,7 +96,7 @@ export default function ContinuityExplorer({
         id="continuity-explorer-panel"
         role="tabpanel"
         aria-labelledby={`continuity-tab-${view}`}
-        className="cadence-surface mt-12"
+        className="cadence-surface mt-8 sm:mt-12"
       >
         {view === "contexts" && (
           <ContextHub

--- a/front/src/components/ContinuitySearch.tsx
+++ b/front/src/components/ContinuitySearch.tsx
@@ -141,7 +141,7 @@ export default function ContinuitySearch({
         <button
           type="submit"
           disabled={query.trim().length < 2 || isSearching}
-          className="rounded-lg border border-violet-500/60 bg-violet-500/10 px-4 py-2 text-sm font-medium text-violet-300 transition-colors duration-150 hover:bg-violet-500/15 disabled:cursor-not-allowed disabled:border-neutral-800 disabled:bg-neutral-900 disabled:text-neutral-600"
+          className="min-h-11 rounded-lg border border-violet-500/60 bg-violet-500/10 px-4 py-2 text-sm font-medium text-violet-300 transition-colors duration-150 hover:bg-violet-500/15 disabled:cursor-not-allowed disabled:border-neutral-800 disabled:bg-neutral-900 disabled:text-neutral-600"
         >
           {isSearching ? "Searching" : "Search"}
         </button>

--- a/front/src/components/DailyPanel.tsx
+++ b/front/src/components/DailyPanel.tsx
@@ -53,7 +53,7 @@ export default function DailyPanel({
   }
 
   return (
-    <div className="mt-12">
+    <div className="mt-6 sm:mt-12">
       {summaryStatus && (
         <p role="status" className="mb-8 text-sm text-neutral-500">
           {summaryStatus}

--- a/front/src/components/DashboardNav.test.tsx
+++ b/front/src/components/DashboardNav.test.tsx
@@ -5,6 +5,20 @@ import { describe, expect, it, vi } from "vitest";
 import DashboardNav from "./DashboardNav";
 
 describe("DashboardNav", () => {
+  it("shows all six workspaces", () => {
+    render(<DashboardNav view="today" onChange={vi.fn()} />);
+    for (const name of [
+      "Today",
+      "Hours",
+      "Focus",
+      "Calendar",
+      "History",
+      "Settings",
+    ]) {
+      screen.getByRole("button", { name });
+    }
+  });
+
   it("moves through the six workspaces by keyboard", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/front/src/components/DashboardNav.tsx
+++ b/front/src/components/DashboardNav.tsx
@@ -45,8 +45,8 @@ export default function DashboardNav({
   }
 
   return (
-    <nav aria-label="Primary" className="cadence-rail mb-12">
-      <div className="flex gap-7 overflow-x-auto pb-3">
+    <nav aria-label="Primary" className="cadence-rail mb-8 sm:mb-12">
+      <div className="grid grid-cols-3 gap-1 pb-2 sm:flex sm:gap-7 sm:overflow-x-auto sm:pb-3">
         {views.map((item) => (
           <button
             key={item.id}
@@ -57,8 +57,8 @@ export default function DashboardNav({
             onKeyDown={(event) => handleKey(event, item.id)}
             className={
               view === item.id
-                ? "border-b border-violet-400 pb-1 text-sm text-neutral-100"
-                : "border-b border-transparent pb-1 text-sm text-neutral-500 transition-colors duration-200 hover:text-neutral-200"
+                ? "min-h-11 rounded-lg bg-neutral-800/80 px-2 text-sm text-neutral-100 sm:rounded-none sm:border-b sm:border-violet-400 sm:bg-transparent sm:px-0 sm:pb-1"
+                : "min-h-11 rounded-lg px-2 text-sm text-neutral-500 transition-colors duration-200 hover:text-neutral-200 sm:rounded-none sm:border-b sm:border-transparent sm:px-0 sm:pb-1"
             }
           >
             {item.label}

--- a/front/src/components/DashboardPage.tsx
+++ b/front/src/components/DashboardPage.tsx
@@ -125,7 +125,7 @@ export default function DashboardPage() {
   }
 
   return (
-    <div className="mx-auto max-w-2xl px-8 py-16">
+    <div className="mx-auto max-w-2xl px-4 pt-[max(1.5rem,env(safe-area-inset-top))] pb-[max(1.5rem,env(safe-area-inset-bottom))] sm:px-8 sm:py-16">
       <Header />
       <DashboardNav view={view} onChange={setView} />
       {actionError && (
@@ -146,7 +146,7 @@ export default function DashboardPage() {
                   type="date"
                   value={selectedDate}
                   onChange={(event) => setSelectedDate(event.target.value)}
-                  className="ml-2 rounded-lg border border-neutral-800 bg-neutral-900 px-2 py-1.5 text-xs text-neutral-300 outline-none transition-colors duration-200 focus:border-neutral-600"
+                  className="ml-2 min-h-11 rounded-lg border border-neutral-800 bg-neutral-900 px-2 py-2 text-base text-neutral-300 outline-none transition-colors duration-200 focus:border-neutral-600 sm:min-h-0 sm:py-1.5 sm:text-xs"
                 />
               </label>
             </div>

--- a/front/src/components/HabitGrid.tsx
+++ b/front/src/components/HabitGrid.tsx
@@ -41,9 +41,10 @@ function HabitGrid({
         {weekdays.map((day) => (
           <div
             key={day}
-            className="pb-2 text-center text-[11px] text-neutral-500"
+            className="pb-1 text-center text-[11px] text-neutral-500 sm:pb-2"
           >
-            {day}
+            <span className="sm:hidden">{day.slice(0, 1)}</span>
+            <span className="hidden sm:inline">{day}</span>
           </div>
         ))}
         {Array.from({ length: leading }, (_, index) => (
@@ -63,8 +64,8 @@ function HabitGrid({
               key={day}
               className={
                 selected
-                  ? "rounded-2xl bg-violet-500/10 p-2.5"
-                  : "rounded-2xl p-2.5"
+                  ? "rounded-xl bg-violet-500/10 p-1.5 sm:rounded-2xl sm:p-2.5"
+                  : "rounded-xl p-1.5 sm:rounded-2xl sm:p-2.5"
               }
             >
               <button
@@ -73,10 +74,10 @@ function HabitGrid({
                 onClick={() => onSelectDate(date)}
                 className={
                   selected
-                    ? "block w-full text-left text-sm text-violet-300"
+                    ? "block min-h-9 w-full text-left text-sm text-violet-300"
                     : isToday
-                      ? "block w-full text-left text-sm text-neutral-200"
-                      : "block w-full text-left text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-200"
+                      ? "block min-h-9 w-full text-left text-sm text-neutral-200"
+                      : "block min-h-9 w-full text-left text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-200"
                 }
               >
                 {day}
@@ -99,7 +100,7 @@ function HabitGrid({
                             onToggle(habit.id, date, active ? "0" : "1");
                           }
                         }}
-                        className="flex h-5 w-5 items-center justify-center"
+                        className="flex h-7 w-7 items-center justify-center sm:h-5 sm:w-5"
                       >
                         <span
                           className={

--- a/front/src/components/Header.tsx
+++ b/front/src/components/Header.tsx
@@ -19,12 +19,12 @@ function Header() {
   }
 
   return (
-    <header className="mb-10 flex items-baseline justify-between gap-4">
-      <h1 className="cadence-mark text-[1.35rem] font-medium text-neutral-100">
+    <header className="mb-6 flex items-center justify-between gap-3 sm:mb-10">
+      <h1 className="cadence-mark min-w-0 text-[1.35rem] font-medium text-neutral-100">
         Cadence
       </h1>
       {user && (
-        <div className="flex items-center gap-3">
+        <div className="flex shrink-0 items-center gap-2 sm:gap-3">
           <button
             type="button"
             onClick={() => setTheme(theme === "light" ? "dark" : "light")}
@@ -32,7 +32,9 @@ function Header() {
           >
             {theme === "light" ? "Dark" : "Light"}
           </button>
-          <span className="text-sm text-neutral-500">{user.username}</span>
+          <span className="hidden text-sm text-neutral-500 sm:inline">
+            {user.username}
+          </span>
           {logoutError && (
             <span role="alert" className="text-xs text-red-400">
               {logoutError}

--- a/front/src/components/HoursPage.tsx
+++ b/front/src/components/HoursPage.tsx
@@ -88,7 +88,7 @@ export default function HoursPage({
             type="date"
             value={date}
             onChange={(event) => onSelectDate(event.target.value)}
-            className="ml-2 rounded-lg border border-neutral-800 bg-neutral-900 px-2 py-1.5 text-xs text-neutral-300 outline-none transition-colors duration-200 focus:border-neutral-600"
+            className="ml-2 min-h-11 rounded-lg border border-neutral-800 bg-neutral-900 px-2 py-2 text-base text-neutral-300 outline-none transition-colors duration-200 focus:border-neutral-600 sm:min-h-0 sm:py-1.5 sm:text-xs"
           />
         </label>
       </div>
@@ -107,10 +107,11 @@ export default function HoursPage({
             <li key={slot.hour}>
               <form
                 onSubmit={(event) => handleSubmit(event, slot.hour)}
+                aria-busy={savingHour === slot.hour}
                 className={
                   active
-                    ? "grid grid-cols-[4.5rem_minmax(0,1fr)_auto] items-center gap-3 rounded-lg bg-violet-500/10 py-2 pr-1"
-                    : "grid grid-cols-[4.5rem_minmax(0,1fr)_auto] items-center gap-3 rounded-lg py-2 pr-1 hover:bg-neutral-950/40"
+                    ? "grid grid-cols-[3.25rem_minmax(0,1fr)] items-center gap-2 rounded-lg bg-violet-500/10 py-1.5 sm:grid-cols-[4.5rem_minmax(0,1fr)_auto] sm:gap-3 sm:py-2 sm:pr-1"
+                    : "grid grid-cols-[3.25rem_minmax(0,1fr)] items-center gap-2 rounded-lg py-1.5 hover:bg-neutral-950/40 sm:grid-cols-[4.5rem_minmax(0,1fr)_auto] sm:gap-3 sm:py-2 sm:pr-1"
                 }
               >
                 <label
@@ -136,9 +137,9 @@ export default function HoursPage({
                   onBlur={() => void saveHour(slot.hour)}
                   placeholder={active ? "Now" : ""}
                   maxLength={2000}
-                  className="min-w-0 rounded-md border border-transparent bg-transparent px-2 py-1.5 text-sm text-neutral-100 outline-none placeholder:text-neutral-600 focus:border-neutral-700 focus:bg-neutral-950"
+                  className="min-h-11 min-w-0 rounded-md border border-transparent bg-transparent px-2 py-2 text-base text-neutral-100 outline-none placeholder:text-neutral-600 focus:border-neutral-700 focus:bg-neutral-950 sm:min-h-0 sm:py-1.5 sm:text-sm"
                 />
-                <span className="w-12 text-right text-[11px] text-neutral-600">
+                <span className="hidden w-12 text-right text-[11px] text-neutral-600 sm:block">
                   {savingHour === slot.hour ? "Saving" : ""}
                 </span>
               </form>

--- a/front/src/components/LoginPage.tsx
+++ b/front/src/components/LoginPage.tsx
@@ -56,7 +56,7 @@ function LoginPage() {
   }
 
   return (
-    <div className="px-6 py-6">
+    <div className="px-4 py-6 pt-[max(1.5rem,env(safe-area-inset-top))] sm:px-6">
       <div className="flex justify-end">
         <button
           type="button"
@@ -208,7 +208,7 @@ function LoginPage() {
                     setMode("register");
                     setError(null);
                   }}
-                  className="w-full text-sm text-neutral-500 hover:text-neutral-300 transition-colors"
+                  className="w-full min-h-11 text-sm text-neutral-500 hover:text-neutral-300 transition-colors"
                 >
                   Need an account? Register
                 </button>
@@ -218,7 +218,7 @@ function LoginPage() {
                     setMode("resend");
                     setError(null);
                   }}
-                  className="w-full text-sm text-neutral-500 hover:text-neutral-300 transition-colors"
+                  className="w-full min-h-11 text-sm text-neutral-500 hover:text-neutral-300 transition-colors"
                 >
                   Resend verification email
                 </button>
@@ -230,7 +230,7 @@ function LoginPage() {
                   setMode("login");
                   setError(null);
                 }}
-                className="w-full text-sm text-neutral-500 hover:text-neutral-300 transition-colors"
+                className="w-full min-h-11 text-sm text-neutral-500 hover:text-neutral-300 transition-colors"
               >
                 Back to login
               </button>

--- a/front/src/components/MonthNav.tsx
+++ b/front/src/components/MonthNav.tsx
@@ -18,7 +18,7 @@ function MonthNav({ month, onChange }: MonthNavProps) {
   });
 
   return (
-    <div className="mb-10 flex items-baseline justify-center gap-3">
+    <div className="mb-8 flex items-center justify-center gap-3 sm:mb-10 sm:items-baseline">
       <button
         type="button"
         aria-label="Previous month"
@@ -27,7 +27,7 @@ function MonthNav({ month, onChange }: MonthNavProps) {
       >
         ←
       </button>
-      <h1 className="cadence-title w-44 text-center text-2xl font-medium text-neutral-100">
+      <h1 className="cadence-title min-w-0 flex-1 text-center text-xl font-medium text-neutral-100 sm:w-44 sm:flex-none sm:text-2xl">
         {label}
       </h1>
       <button

--- a/front/src/components/RecentDays.tsx
+++ b/front/src/components/RecentDays.tsx
@@ -43,7 +43,7 @@ export default function RecentDays({
           <button
             key={day.id}
             onClick={() => onSelect(day.date)}
-            className="block w-full rounded-lg px-1 py-2 text-left hover:bg-neutral-950/40"
+            className="block min-h-11 w-full rounded-lg px-1 py-3 text-left hover:bg-neutral-950/40"
           >
             <span
               className={

--- a/front/src/components/VerifyPage.tsx
+++ b/front/src/components/VerifyPage.tsx
@@ -41,7 +41,7 @@ function VerifyPage() {
   }, []);
 
   return (
-    <div className="max-w-sm mx-auto px-6 py-16 text-center">
+    <div className="mx-auto max-w-sm px-4 py-10 text-center sm:px-6 sm:py-16">
       <h1 className="cadence-mark text-xl font-semibold text-neutral-100 tracking-tight mb-8">
         Cadence
       </h1>

--- a/front/src/components/daily/CarryForwardCard.tsx
+++ b/front/src/components/daily/CarryForwardCard.tsx
@@ -91,11 +91,11 @@ export default function CarryForwardCard({
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
           maxLength={2000}
-          className="min-w-0 flex-1 rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 outline-none placeholder:text-neutral-600 focus:border-neutral-600"
+          className="min-h-11 min-w-0 flex-1 rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2 text-base text-neutral-100 outline-none placeholder:text-neutral-600 focus:border-neutral-600 sm:min-h-0 sm:text-sm"
         />
         <button
           disabled={isSubmitting || draft.trim().length === 0}
-          className="rounded-lg bg-neutral-800 px-3 py-2 text-xs text-neutral-200 transition-colors duration-150 hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="min-h-11 rounded-lg bg-neutral-800 px-3 py-2 text-sm text-neutral-200 transition-colors duration-150 hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-50 sm:text-xs"
         >
           {isSubmitting ? "Adding" : "Add"}
         </button>

--- a/front/src/components/daily/DailyHabitsCard.tsx
+++ b/front/src/components/daily/DailyHabitsCard.tsx
@@ -127,14 +127,14 @@ export default function DailyHabitsCard({
                 checked={habit.completed}
                 onChange={() => toggle(habit)}
                 aria-label={`Mark ${habit.name} complete for ${date}`}
-                className="h-5 w-5 accent-violet-500"
+                className="h-6 w-6 accent-violet-500"
               />
             </label>
           ))}
         </div>
       ) : null}
 
-      <form onSubmit={addHabit} className="mt-5 flex gap-3">
+      <form onSubmit={addHabit} className="mt-5 flex gap-2 sm:gap-3">
         <label htmlFor="new-daily-habit" className="sr-only">
           Add a habit
         </label>
@@ -144,12 +144,12 @@ export default function DailyHabitsCard({
           onChange={(event) => setNewName(event.target.value)}
           placeholder="Add a habit"
           maxLength={100}
-          className="min-w-0 flex-1 rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 outline-none placeholder:text-neutral-600 focus:border-neutral-600"
+          className="min-h-11 min-w-0 flex-1 rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2 text-base text-neutral-100 outline-none placeholder:text-neutral-600 focus:border-neutral-600 sm:min-h-0 sm:text-sm"
         />
         <button
           type="submit"
           disabled={isSaving || newName.trim().length === 0}
-          className="rounded-lg bg-neutral-800 px-3 py-2 text-xs text-neutral-200 transition-colors duration-150 hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="min-h-11 rounded-lg bg-neutral-800 px-3 py-2 text-sm text-neutral-200 transition-colors duration-150 hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-50 sm:text-xs"
         >
           {isSaving ? "Adding" : "Add"}
         </button>

--- a/front/src/components/daily/QuickThreadCard.tsx
+++ b/front/src/components/daily/QuickThreadCard.tsx
@@ -162,12 +162,12 @@ export default function QuickThreadCard({
                 ? "Write as much or as little as you need"
                 : "What happened just now?"
             }
-            className="min-w-0 flex-1 rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 outline-none placeholder:text-neutral-600 focus:border-neutral-600"
+            className="min-h-11 min-w-0 flex-1 rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2 text-base text-neutral-100 outline-none placeholder:text-neutral-600 focus:border-neutral-600 sm:min-h-0 sm:text-sm"
           />
           <button
             type="submit"
             disabled={isSubmitting || draft.trim().length === 0}
-            className="rounded-lg border border-neutral-800 px-3 py-2 text-xs text-neutral-300 transition-colors duration-150 hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50"
+            className="min-h-11 rounded-lg border border-neutral-800 px-3 py-2 text-sm text-neutral-300 transition-colors duration-150 hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50 sm:text-xs"
           >
             {isSubmitting ? "Saving" : "Log"}
           </button>

--- a/front/src/styles/base.css
+++ b/front/src/styles/base.css
@@ -93,6 +93,7 @@ html.dark {
 html {
   background-color: var(--canvas);
   color: var(--n-200);
+  overflow-x: clip;
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -106,6 +107,9 @@ html {
 body {
   position: relative;
   min-height: 100vh;
+  min-height: 100dvh;
+  max-width: 100%;
+  overflow-x: clip;
   background-color: var(--canvas);
   color: var(--n-200);
   font-family: "Source Sans 3", "Segoe UI", system-ui, sans-serif;
@@ -170,8 +174,14 @@ html.dark body::before {
 .cadence-surface {
   background: var(--n-900);
   border-radius: 1.15rem;
-  padding: 1.35rem 1.4rem 1.45rem;
+  padding: 1.1rem 1rem 1.2rem;
   box-shadow: var(--shadow-page);
+}
+
+@media (min-width: 640px) {
+  .cadence-surface {
+    padding: 1.35rem 1.4rem 1.45rem;
+  }
 }
 
 .cadence-chip {
@@ -180,11 +190,20 @@ html.dark body::before {
   font-family: inherit;
   border-radius: 0.55rem;
   background: var(--n-900);
-  padding: 0.35rem 0.7rem;
+  min-height: 2.75rem;
+  padding: 0.5rem 0.85rem;
   font-size: 0.875rem;
   line-height: 1.25rem;
   color: var(--n-400);
   box-shadow: var(--shadow-page);
+  touch-action: manipulation;
+}
+
+@media (min-width: 640px) {
+  .cadence-chip {
+    min-height: 0;
+    padding: 0.35rem 0.7rem;
+  }
 }
 
 .cadence-chip:hover {
@@ -197,6 +216,19 @@ html.dark body::before {
 
 .cadence-chip-accent:hover {
   color: var(--v-200);
+}
+
+button,
+summary {
+  touch-action: manipulation;
+}
+
+@media (max-width: 639px) {
+  input,
+  select,
+  textarea {
+    font-size: 1rem;
+  }
 }
 
 .cadence-rail {


### PR DESCRIPTION
## Summary
- Tighten the page shell, header, and primary nav for a 390px viewport so six destinations stay tappable instead of a sideways scroller.
- Enlarge chips, fields, and calendar/hours controls to 44px targets, keep 16px input type on small screens so iOS does not zoom, and clip horizontal overflow.

## Test plan
- [x] Frontend unit tests (`DashboardNav` plus existing suites)
- [x] Login/register at 390px: no overflow, 44px tap targets
- [ ] After merge: Today, Hours, Calendar, History, Focus, Settings on a real phone