### PR TITLE
Keep the UI calm: arrow on buttons, moon and sun for theme

### DIFF
--- a/front/src/components/ContextManager.tsx
+++ b/front/src/components/ContextManager.tsx
@@ -78,7 +78,7 @@ export default function ContextManager({
 
   return (
     <details>
-      <summary className="cursor-pointer text-sm text-neutral-400 hover:text-neutral-200">
+      <summary className="text-sm text-neutral-400 hover:text-neutral-200">
         Manage areas
       </summary>
       <div className="pt-5">

--- a/front/src/components/DevAIModels.tsx
+++ b/front/src/components/DevAIModels.tsx
@@ -63,7 +63,7 @@ export default function DevAIModels() {
 
   return (
     <details>
-      <summary className="cursor-pointer text-sm text-neutral-500 hover:text-neutral-300">
+      <summary className="text-sm text-neutral-500 hover:text-neutral-300">
         Developer · NVIDIA models
       </summary>
       <div className="pt-5">

--- a/front/src/components/GoalsSettings.tsx
+++ b/front/src/components/GoalsSettings.tsx
@@ -64,7 +64,7 @@ export default function GoalsSettings() {
 
   return (
     <details>
-      <summary className="cursor-pointer text-sm text-neutral-400 hover:text-neutral-200">
+      <summary className="text-sm text-neutral-400 hover:text-neutral-200">
         Goals
       </summary>
       <div className="pt-5">

--- a/front/src/components/HabitManager.tsx
+++ b/front/src/components/HabitManager.tsx
@@ -50,7 +50,7 @@ export default function HabitManager({
 
   return (
     <details>
-      <summary className="cursor-pointer text-sm text-neutral-400 hover:text-neutral-200">
+      <summary className="text-sm text-neutral-400 hover:text-neutral-200">
         Manage habits
       </summary>
       <div className="pt-5">

--- a/front/src/components/Header.tsx
+++ b/front/src/components/Header.tsx
@@ -1,10 +1,9 @@
 import { useState } from "react";
 import { useAuth } from "../contexts/AuthContext";
-import { useTheme } from "../contexts/ThemeContext";
+import ThemeToggle from "./ThemeToggle";
 
 function Header() {
   const { user, logout } = useAuth();
-  const { theme, setTheme } = useTheme();
   const [logoutError, setLogoutError] = useState<string | null>(null);
 
   async function handleLogout() {
@@ -25,13 +24,7 @@ function Header() {
       </h1>
       {user && (
         <div className="flex shrink-0 items-center gap-2 sm:gap-3">
-          <button
-            type="button"
-            onClick={() => setTheme(theme === "light" ? "dark" : "light")}
-            className="cadence-chip"
-          >
-            {theme === "light" ? "Dark" : "Light"}
-          </button>
+          <ThemeToggle />
           <span className="hidden text-sm text-neutral-500 sm:inline">
             {user.username}
           </span>

--- a/front/src/components/LoginPage.tsx
+++ b/front/src/components/LoginPage.tsx
@@ -1,10 +1,9 @@
 import { useState, type FormEvent } from "react";
 import { useAuth } from "../contexts/AuthContext";
-import { useTheme } from "../contexts/ThemeContext";
+import ThemeToggle from "./ThemeToggle";
 
 function LoginPage() {
   const { login, register, resendVerification } = useAuth();
-  const { theme, setTheme } = useTheme();
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -58,13 +57,7 @@ function LoginPage() {
   return (
     <div className="px-4 py-6 pt-[max(1.5rem,env(safe-area-inset-top))] sm:px-6">
       <div className="flex justify-end">
-        <button
-          type="button"
-          onClick={() => setTheme(theme === "light" ? "dark" : "light")}
-          className="cadence-chip"
-        >
-          {theme === "light" ? "Dark" : "Light"}
-        </button>
+        <ThemeToggle />
       </div>
       <div className="cadence-surface mx-auto mt-10 max-w-sm">
       <h1 className={`cadence-mark text-center text-xl font-semibold tracking-tight text-neutral-100 ${checkEmail ? "mb-6" : "mb-2"}`}>

--- a/front/src/components/ThemeToggle.test.tsx
+++ b/front/src/components/ThemeToggle.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { ThemeProvider } from "../contexts/ThemeContext";
+import ThemeToggle from "./ThemeToggle";
+
+describe("ThemeToggle", () => {
+  it("uses a moon or sun instead of a text label", async () => {
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider>
+        <ThemeToggle />
+      </ThemeProvider>,
+    );
+
+    const toggle = screen.getByRole("button", { name: "Dark" });
+    expect(toggle.querySelector("svg")).toBeTruthy();
+    await user.click(toggle);
+    expect(screen.getByRole("button", { name: "Light" }).querySelector("svg")).toBeTruthy();
+  });
+});

--- a/front/src/components/ThemeToggle.tsx
+++ b/front/src/components/ThemeToggle.tsx
@@ -1,0 +1,60 @@
+import { useTheme } from "../contexts/ThemeContext";
+
+function MoonMark() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="h-[1.05rem] w-[1.05rem]"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M14.8 4.2A8.2 8.2 0 1 0 20 15.4 6.6 6.6 0 0 1 14.8 4.2Z"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function SunMark() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="h-[1.05rem] w-[1.05rem]"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r="3.5"
+        stroke="currentColor"
+        strokeWidth="1.4"
+      />
+      <path
+        d="M12 3.2v1.6M12 19.2v1.6M3.2 12h1.6M19.2 12h1.6"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const next = theme === "light" ? "dark" : "light";
+
+  return (
+    <button
+      type="button"
+      aria-label={next === "dark" ? "Dark" : "Light"}
+      onClick={() => setTheme(next)}
+      className="cadence-chip cadence-chip-icon"
+    >
+      {next === "dark" ? <MoonMark /> : <SunMark />}
+    </button>
+  );
+}

--- a/front/src/components/daily/CarryForwardCard.tsx
+++ b/front/src/components/daily/CarryForwardCard.tsx
@@ -79,7 +79,7 @@ export default function CarryForwardCard({
 
   return (
     <details className="py-2">
-      <summary className="cursor-pointer text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-200">
+      <summary className="text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-200">
         Follow-ups
       </summary>
       <form onSubmit={addItem} className="mt-4 flex gap-2">

--- a/front/src/components/daily/DailyCaptureCard.tsx
+++ b/front/src/components/daily/DailyCaptureCard.tsx
@@ -231,7 +231,7 @@ export default function DailyCaptureCard({
           )}
 
           <details className="mt-8">
-            <summary className="cursor-pointer text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-300">
+            <summary className="text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-300">
               Check-in
             </summary>
             <div className="mt-2 grid grid-cols-2 gap-3">
@@ -256,7 +256,7 @@ export default function DailyCaptureCard({
           </details>
 
           <details className="mt-6">
-            <summary className="cursor-pointer text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-300">
+            <summary className="text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-300">
               Add more detail
             </summary>
             <div className="mt-3 grid grid-cols-2 gap-3">

--- a/front/src/components/daily/DailySummaryCard.tsx
+++ b/front/src/components/daily/DailySummaryCard.tsx
@@ -90,7 +90,7 @@ export default function DailySummaryCard({
     <details className="py-2">
       <summary
         id="daily-summary-title"
-        className="cursor-pointer text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-200"
+        className="text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-200"
       >
         Daily review
       </summary>

--- a/front/src/components/daily/DayClosureCard.tsx
+++ b/front/src/components/daily/DayClosureCard.tsx
@@ -68,7 +68,7 @@ export default function DayClosureCard({
     <details className="py-2">
       <summary
         id="day-closure-title"
-        className="cursor-pointer text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-200"
+        className="text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-200"
       >
         Finish the day
       </summary>

--- a/front/src/focus/StudyScene.tsx
+++ b/front/src/focus/StudyScene.tsx
@@ -36,7 +36,7 @@ export default function StudyScene() {
   return (
     <button
       type="button"
-      className="relative block aspect-[16/9] w-full cursor-pointer overflow-hidden border-0 bg-neutral-900 p-0"
+      className="relative block aspect-[16/9] w-full overflow-hidden border-0 bg-neutral-900 p-0"
       aria-label="Study scene"
       onClick={() => setIndex((current) => (current + 1) % cats.length)}
     >

--- a/front/src/styles/base.css
+++ b/front/src/styles/base.css
@@ -186,7 +186,6 @@ html.dark body::before {
 
 .cadence-chip {
   border: 0;
-  cursor: pointer;
   font-family: inherit;
   border-radius: 0.55rem;
   background: var(--n-900);
@@ -210,6 +209,21 @@ html.dark body::before {
   color: var(--n-200);
 }
 
+.cadence-chip-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  padding: 0;
+}
+
+@media (min-width: 640px) {
+  .cadence-chip-icon {
+    width: 2.15rem;
+    min-height: 2.15rem;
+  }
+}
+
 .cadence-chip-accent {
   color: var(--v-300);
 }
@@ -218,9 +232,18 @@ html.dark body::before {
   color: var(--v-200);
 }
 
+a[href] {
+  cursor: pointer;
+}
+
 button,
 summary {
+  cursor: default;
   touch-action: manipulation;
+}
+
+button:disabled {
+  cursor: not-allowed;
 }
 
 @media (max-width: 639px) {


### PR DESCRIPTION
## Summary
- Buttons and disclosures keep the native arrow. The pointing hand is only for real links.
- Dark/Light text is a moon or sun mark.

## Test plan
- [ ] Hover Log in, nav, chips: arrow. Hover a verify-page link: hand.
- [ ] Theme toggle shows a moon in light and a sun in dark; it still switches theme.