### PR TITLE
Normalise line endings so the container starts on Windows clones

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.pdf binary


### PR DESCRIPTION
## What

Adds a `.gitattributes` pinning text files to LF.

## Why

Git for Windows defaults to `core.autocrlf=true`. With no `.gitattributes`, `docker/entrypoint.sh` and `scripts/*.sh` check out with CRLF, the shebang line ends in `\r`, and the container exits immediately:

```
app-1  | exec /app/docker/entrypoint.sh: no such file or directory
```

This is on the documented `./scripts/quickstart.sh` path, so a fresh Windows clone cannot start the app at all.

## How it was tested

On Windows with `core.autocrlf=true`:

- Before: `docker compose up --build` builds, then `cadence-app-1` exits with the error above.
- After: deleted `docker/entrypoint.sh` and `scripts/quickstart.sh`, re-checked them out, and confirmed `file` reports `POSIX shell script, ASCII text executable` with no CRLF. The container then starts, Alembic runs, and `/healthz` returns 200.
- `git add --renormalize .` reports no content change to any tracked file, so this only affects how files are written into the working tree.