### PR TITLE
Let the published PostgreSQL port be overridden

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ CADENCE_SECRET_KEY=replace-with-a-long-random-value
 CADENCE_POSTGRES_DB=cadence
 CADENCE_POSTGRES_USER=cadence
 CADENCE_POSTGRES_PASSWORD=cadence-local-password
+# Host port Compose publishes PostgreSQL on. Change it when 5432 is already
+# taken locally, and match it in the localhost URLs below.
+CADENCE_POSTGRES_HOST_PORT=5432
 # Compose runs the app on a private network, so its URLs must use the `db`
 # service name. Set the migration URL separately only when it differs from the
 # runtime URL (for example, a direct database endpoint).

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ services:
       POSTGRES_USER: ${CADENCE_POSTGRES_USER:-cadence}
       POSTGRES_PASSWORD: ${CADENCE_POSTGRES_PASSWORD:-cadence-local-password}
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:${CADENCE_POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
       - cadence-postgres:/var/lib/postgresql/data
       - ./docker/postgres/init:/docker-entrypoint-initdb.d:ro


### PR DESCRIPTION
## What

`CADENCE_POSTGRES_HOST_PORT`, defaulting to `5432`, replaces the hard-coded host port in `compose.yaml`.

## Why

`docker compose up` aborts on any machine already running PostgreSQL, or another project's database container:

```
Error response from daemon: failed to set up container networking:
Bind for 0.0.0.0:5432 failed: port is already allocated
```

The publish cannot simply be removed: CONTRIBUTING documents running Alembic and the test suite from the host against `localhost:5432`, so the port has to stay reachable. Making it configurable lets a contributor move it without editing a tracked file.

## How it was tested

- `docker compose config` shows `published: "5432"` with no variable set.
- `CADENCE_POSTGRES_HOST_PORT=5433 docker compose config` shows `published: "5433"`.
- Brought the stack up on 5433 alongside an unrelated container holding 5432; migrations ran and `/healthz` returned 200.