### PR TITLE
Stop the light-theme flash on every dark-mode load

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -4,13 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Cadence: habits, hours, focus</title>
-    <script>
-      try {
-        if (localStorage.getItem("cadence-theme") === "dark") {
-          document.documentElement.classList.add("dark");
-        }
-      } catch (error) {}
-    </script>
+    <script src="/theme.js"></script>
 </head>
 <body>
     <div id="app"></div>

--- a/front/public/theme.js
+++ b/front/public/theme.js
@@ -1,0 +1,5 @@
+try {
+  if (localStorage.getItem("cadence-theme") === "dark") {
+    document.documentElement.classList.add("dark");
+  }
+} catch (error) {}


### PR DESCRIPTION
## What

Moves the theme bootstrap out of an inline `<script>` in `index.html` into `front/public/theme.js`.

## Why

The app sends `script-src 'self'` with no hash or nonce, so the browser blocks the inline bootstrap on every load:

```
Executing inline script violates the following Content Security Policy
directive 'script-src 'self''
```

The `dark` class was therefore applied only after React mounted. Because `html` also carries a 280ms `background-color` transition, a dark-mode user saw the page paint in light `#e6ddd0` and *animate* down to `#100e0c`.

Measured on a cold load with `cadence-theme=dark`:

| t | `html.class` | background |
|---|---|---|
| 368ms | `""` | (light) |
| 415ms | `"dark"` | `rgb(176,169,159)` |
| 469ms | `"dark"` | `rgb(70,67,62)` |
| 657ms | `"dark"` | `rgb(16,14,12)` |

Roughly 250ms of visible full-screen flash, on every navigation.

A same-origin script file is already allowed by the existing policy, so this needs no CSP change and no build-time hash to keep in sync.

## How it was tested

Against the built image, so the real CSP header is in play.

- The CSP violation no longer appears in the console; the only remaining console error is the expected 401 from `/api/auth/me` when logged out.
- The same measurement now goes straight to `rgb(16,14,12)` with no intermediate values.
- With the stylesheet request delayed by 300ms, `document.documentElement.className` is already `"dark"` before CSS finishes loading, so no light frame can paint.
- `/theme.js` serves 200 as `text/javascript`, in dev (Vite) and from `front/dist` in the container.

Behaviour is otherwise unchanged: first visit still defaults to light, and the toggle still animates.