### PR TITLE
Give completion its own colour instead of reusing the alert red

### DIFF
--- a/front/src/components/AIPrivacySettings.tsx
+++ b/front/src/components/AIPrivacySettings.tsx
@@ -51,7 +51,7 @@ export default function AIPrivacySettings() {
             type="checkbox"
             checked={consent}
             onChange={(event) => setConsent(event.target.checked)}
-            className="mt-0.5 accent-violet-400"
+            className="mt-0.5 accent-done"
           />
           <span>
             Allow automatic summaries to use today’s notes
@@ -66,7 +66,7 @@ export default function AIPrivacySettings() {
             type="checkbox"
             checked={redaction}
             onChange={(event) => setRedaction(event.target.checked)}
-            className="mt-0.5 accent-violet-400"
+            className="mt-0.5 accent-done"
           />
           <span>
             Redact common email addresses and phone-like numbers

--- a/front/src/components/DayHabitsDialog.tsx
+++ b/front/src/components/DayHabitsDialog.tsx
@@ -133,7 +133,7 @@ export default function DayHabitsDialog({
                       onToggle(habit.id, date, completed ? "0" : "1")
                     }
                     aria-label={`Mark ${habit.name} complete for ${date}`}
-                    className="h-6 w-6 accent-violet-500"
+                    className="h-6 w-6 accent-done"
                   />
                 </label>
               );
@@ -163,7 +163,7 @@ export default function DayHabitsDialog({
                   checked={task.is_completed}
                   onChange={() => onToggleTask(task)}
                   aria-label={`Mark ${task.title} complete`}
-                  className="h-6 w-6 accent-violet-500"
+                  className="h-6 w-6 accent-done"
                 />
               </label>
             ))}

--- a/front/src/components/TasksPage.tsx
+++ b/front/src/components/TasksPage.tsx
@@ -231,7 +231,7 @@ function TaskRow({
         checked={task.is_completed}
         onChange={onToggle}
         aria-label={`Mark ${task.title} complete`}
-        className="h-6 w-6 shrink-0 accent-violet-500"
+        className="h-6 w-6 shrink-0 accent-done"
       />
       <span
         className={

--- a/front/src/components/daily/DailyCaptureCard.tsx
+++ b/front/src/components/daily/DailyCaptureCard.tsx
@@ -228,7 +228,7 @@ export default function DailyCaptureCard({
                       checked={selectedContextIds.includes(context.id)}
                       disabled={context.is_archived}
                       onChange={() => toggleContext(context.id)}
-                      className="accent-violet-500"
+                      className="accent-done"
                     />
                     <span>
                       {context.name}

--- a/front/src/components/daily/DailyHabitsCard.tsx
+++ b/front/src/components/daily/DailyHabitsCard.tsx
@@ -127,7 +127,7 @@ export default function DailyHabitsCard({
                 checked={habit.completed}
                 onChange={() => toggle(habit)}
                 aria-label={`Mark ${habit.name} complete for ${date}`}
-                className="h-6 w-6 accent-violet-500"
+                className="h-6 w-6 accent-done"
               />
             </label>
           ))}

--- a/front/src/styles/base.css
+++ b/front/src/styles/base.css
@@ -18,6 +18,7 @@
   --v-300: #b55238;
   --v-400: #c45c3e;
   --v-500: #c45c3e;
+  --done: #4f7a4a;
   --red-300: #9a2f2a;
   --red-400: #b42318;
   --red-900: #edd5d1;
@@ -58,6 +59,7 @@ html.dark {
   --v-300: #e09a84;
   --v-400: #d98970;
   --v-500: #c45c3e;
+  --done: #8fad88;
   --red-300: #f0b4ae;
   --red-400: #e88980;
   --red-900: #5c2a26;
@@ -93,6 +95,7 @@ html.dark {
   --color-violet-300: var(--v-300);
   --color-violet-400: var(--v-400);
   --color-violet-500: var(--v-500);
+  --color-done: var(--done);
   --color-red-300: var(--red-300);
   --color-red-400: var(--red-400);
   --color-red-900: var(--red-900);


### PR DESCRIPTION
## What

Adds a `--done` sage token and points every checkbox at it, instead of `accent-violet-500`.

## Why

`accent-violet-500` resolves to the terracotta accent. Measured hue angles:

- completion `#c45c3e` → **13.4°**
- error `#b42318` → **4.2°**

Nine degrees apart. A finished habit and a failed request render in effectively the same colour, and a column of ticked habits reads pre-attentively as a column of alerts rather than a list of wins.

The accent was also carrying four other meanings: active tab, today's date, active History sub-tab, and the current hour in Hours. Five meanings on one colour is no meaning at all.

After this, terracotta means only "you are here" and red means only "something is wrong".

## How it was tested

- Built and checked both themes in the browser; ticked habits, tasks and the AI-preferences toggles are sage, while the nav underline, today's date and the "Now" row stay terracotta.
- Non-text contrast for the new token clears the 3:1 minimum: **4.67:1** light, **7.14:1** dark.
- `npx vitest run`: no new failures.

Only the accent classes changed; no layout or markup changes.

<sub>One unrelated test, `DisciplineContinuity.test.tsx`, also fails on a clean `main` in my environment: it asserts a button named `Jul 5`, but the component formats with `toLocaleDateString(undefined, …)` and my system locale is `en-IN`, which renders `5 Jul`. It passes under `en-US`, so CI is unaffected.</sub>