### PR TITLE
Restore the focus ring on inputs and raise small tap targets

### DIFF
--- a/front/src/styles/base.css
+++ b/front/src/styles/base.css
@@ -363,6 +363,32 @@ summary {
   touch-action: manipulation;
 }
 
+button,
+summary {
+  min-height: 1.5rem;
+}
+
+button {
+  min-width: 1.5rem;
+}
+
+summary {
+  padding-block: 0.25rem;
+}
+
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline-style: solid;
+  outline-width: 2px;
+  outline-color: var(--v-400);
+  outline-offset: 2px;
+}
+
+label:has(> input[type="checkbox"]) {
+  min-height: 1.5rem;
+}
+
 button:disabled {
   cursor: not-allowed;
 }


### PR DESCRIPTION
## What

Four rules in `base.css` restore a keyboard focus indicator on form controls and bring undersized targets up to 24x24.

## Why

**No focus indicator on any text input.** 34 form controls carry `outline-none` or `focus:outline-none` with only a border-colour change on focus. Tabbing to either field on the login form showed `outline-style: none` and no replacement ring. Buttons keep the native ring and were fine.

**Targets below the 24x24 minimum** (WCAG 2.5.8):

| element | size |
|---|---|
| "Remove" on each task row | 41x16 |
| History week arrows | 12x20 |
| "Generate" / "Save" | 53x20, 28x20 |
| Calendar habit-legend buttons | ~57x16 |
| every `<summary>` disclosure | 563x20 |
| "Areas" checkboxes | 13x13 |

## How

Rather than editing 34 call sites, these live in `base.css`. They are unlayered, so they take precedence over the Tailwind utility layer without `!important`:

- a 2px `:focus-visible` outline on `input`, `select`, `textarea`
- a `1.5rem` minimum on `button` and `summary`
- `padding-block` on `summary`, which has no intrinsic height
- a `1.5rem` minimum on labels wrapping a checkbox, so the label rather than the 13px box is the target

## How it was tested

- Keyboard-focused the login field: `outline: solid 2px rgb(196,92,62)` at 2px offset. `:focus-visible` means mouse clicks do not show a ring.
- Re-ran the target audit across all seven views: **no remaining element under 24x24**. The `<input type=checkbox>` boxes stay visually 13px, but their wrapping labels now measure 54x24 / 47x24, and the label is the clickable target.
- `npx vitest run` shows no new failures.