### PR TITLE
Give removing a task an undo window

### DIFF
--- a/front/src/components/TasksPage.test.tsx
+++ b/front/src/components/TasksPage.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
-import { createTask, fetchTasks, updateTask } from "../api";
+import { createTask, deleteTask, fetchTasks, updateTask } from "../api";
 import { todayAsLocalDate } from "../time";
 import TasksPage from "./TasksPage";
 
@@ -49,5 +49,63 @@ describe("TasksPage", () => {
       }),
     );
     expect(updateTask).toHaveBeenCalledWith(4, { is_completed: true });
+  });
+
+  it("keeps a removed task until the undo window closes", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime.bind(vi),
+    });
+    vi.mocked(fetchTasks).mockResolvedValue([
+      {
+        id: 9,
+        title: "Water the plants",
+        due_date: todayAsLocalDate(),
+        is_completed: false,
+        completed_at: null,
+      },
+    ]);
+    vi.mocked(deleteTask).mockResolvedValue(undefined as never);
+
+    render(<TasksPage refreshKey={0} onChanged={vi.fn()} />);
+    await user.click(
+      await screen.findByRole("button", { name: "Remove Water the plants" }),
+    );
+
+    expect(screen.queryByText("Water the plants")).toBeNull();
+    expect(deleteTask).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Undo" }));
+
+    expect(screen.getByText("Water the plants")).toBeTruthy();
+    vi.advanceTimersByTime(10000);
+    expect(deleteTask).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("deletes a removed task once the undo window closes", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime.bind(vi),
+    });
+    vi.mocked(fetchTasks).mockResolvedValue([
+      {
+        id: 9,
+        title: "Water the plants",
+        due_date: todayAsLocalDate(),
+        is_completed: false,
+        completed_at: null,
+      },
+    ]);
+    vi.mocked(deleteTask).mockResolvedValue(undefined as never);
+
+    render(<TasksPage refreshKey={0} onChanged={vi.fn()} />);
+    await user.click(
+      await screen.findByRole("button", { name: "Remove Water the plants" }),
+    );
+
+    vi.advanceTimersByTime(6000);
+    await waitFor(() => expect(deleteTask).toHaveBeenCalledWith(9));
+    vi.useRealTimers();
   });
 });

--- a/front/src/components/TasksPage.tsx
+++ b/front/src/components/TasksPage.tsx
@@ -9,9 +9,17 @@ import {
 } from "../api";
 import { todayAsLocalDate } from "../time";
 
+const UNDO_WINDOW_MS = 6000;
+
 interface TasksPageProps {
   refreshKey: number;
   onChanged: () => void;
+}
+
+interface PendingRemoval {
+  task: TaskItem;
+  index: number;
+  timer: number;
 }
 
 export default function TasksPage({ refreshKey, onChanged }: TasksPageProps) {
@@ -21,7 +29,20 @@ export default function TasksPage({ refreshKey, onChanged }: TasksPageProps) {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
+  const [removed, setRemoved] = useState<TaskItem | null>(null);
   const loaded = useRef(false);
+  const pendingRemoval = useRef<PendingRemoval | null>(null);
+
+  useEffect(
+    () => () => {
+      const pending = pendingRemoval.current;
+      if (!pending) return;
+      window.clearTimeout(pending.timer);
+      pendingRemoval.current = null;
+      void deleteTask(pending.task.id).catch(() => undefined);
+    },
+    [],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -116,18 +137,55 @@ export default function TasksPage({ refreshKey, onChanged }: TasksPageProps) {
     }
   }
 
-  async function remove(task: TaskItem) {
-    setError(null);
-    setTasks((current) => current.filter((item) => item.id !== task.id));
+  function flushPendingRemoval() {
+    const pending = pendingRemoval.current;
+    if (!pending) return;
+    window.clearTimeout(pending.timer);
+    void commitRemoval(pending.task, pending.index);
+  }
+
+  async function commitRemoval(task: TaskItem, index: number) {
+    pendingRemoval.current = null;
+    setRemoved(null);
     try {
       await deleteTask(task.id);
       onChanged();
     } catch (caught) {
-      setTasks((current) => [...current, task]);
+      setTasks((current) => {
+        const next = [...current];
+        next.splice(Math.min(index, next.length), 0, task);
+        return next;
+      });
       setError(
         caught instanceof Error ? caught.message : "Could not remove the task",
       );
     }
+  }
+
+  function remove(task: TaskItem) {
+    setError(null);
+    flushPendingRemoval();
+    const index = tasks.findIndex((item) => item.id === task.id);
+    setTasks((current) => current.filter((item) => item.id !== task.id));
+    const timer = window.setTimeout(() => {
+      void commitRemoval(task, index);
+    }, UNDO_WINDOW_MS);
+    pendingRemoval.current = { task, index, timer };
+    setRemoved(task);
+  }
+
+  function undoRemove() {
+    const pending = pendingRemoval.current;
+    if (!pending) return;
+    window.clearTimeout(pending.timer);
+    pendingRemoval.current = null;
+    setRemoved(null);
+    setTasks((current) => {
+      if (current.some((item) => item.id === pending.task.id)) return current;
+      const next = [...current];
+      next.splice(Math.min(pending.index, next.length), 0, pending.task);
+      return next;
+    });
   }
 
   const open = tasks.filter((task) => !task.is_completed);
@@ -143,6 +201,20 @@ export default function TasksPage({ refreshKey, onChanged }: TasksPageProps) {
           {error}
         </p>
       )}
+      <div role="status" aria-live="polite">
+        {removed && (
+          <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-neutral-500">
+            <span>Removed &ldquo;{removed.title}&rdquo;</span>
+            <button
+              type="button"
+              onClick={undoRemove}
+              className="min-h-6 px-1 text-xs text-violet-300 hover:text-violet-200"
+            >
+              Undo
+            </button>
+          </div>
+        )}
+      </div>
       <div className="cadence-surface mt-10">
         {isLoading && tasks.length === 0 ? (
           <p className="text-sm text-neutral-600">Loading tasks...</p>
@@ -255,6 +327,7 @@ function TaskRow({
       <button
         type="button"
         onClick={onRemove}
+        aria-label={`Remove ${task.title}`}
         className="text-xs text-neutral-500 hover:text-neutral-200"
       >
         Remove


### PR DESCRIPTION
## What

Removing a task now holds the delete for six seconds behind an Undo control.

## Why

Removal called `deleteTask` immediately, with no confirmation and no way back, from a 41x16 text button sitting right beside the due-date field. One mis-click destroyed the task permanently. Verified before the change:

```
Task "Remove": confirm dialog? NO | rows 5 -> 4 | undo offered? NO
```

## How

Removal hides the row and defers the API call. Undo restores the row and **never calls the API**, so the task keeps its id, due date and completion state rather than being recreated with new ones.

- letting the window lapse sends the delete exactly once
- a second removal commits the pending one first
- unmounting commits the pending delete
- if the request fails, the row returns to its original index with the existing error message

An undo toast was chosen over a confirm dialog deliberately: a confirm adds a decision to every removal, while undo only costs something when a mistake was actually made.

The Remove buttons also had no accessible name beyond "Remove", so a screen reader announced several identical buttons. They now carry the task title, matching the checkbox above them.

## How it was tested

Two new tests in `TasksPage.test.tsx` cover undoing within the window and deleting after it. Full suite: 68 passed.

End-to-end against the built image, watching outbound requests:

```
removed: Remove Call the clinic about the follow-up
  undo offered?    YES
  DELETE sent yet? no (deferred)
  after undo: rows 4 -> 4 RESTORED, DELETE calls total: 0
  after 7s no undo: rows 4 -> 3, DELETE calls: 1
  after reload rows: 3 (persisted)
```

<sub>One unrelated test, `DisciplineContinuity.test.tsx`, also fails on a clean `main` in my environment: it asserts a button named `Jul 5`, but the component formats with `toLocaleDateString(undefined, …)` and my system locale is `en-IN`, which renders `5 Jul`. It passes under `en-US`, so CI is unaffected.</sub>