### PR TITLE
Fix focus fullscreen, rain without lo-fi, and phone tap targets

### DIFF
--- a/front/src/components/FocusPage.test.tsx
+++ b/front/src/components/FocusPage.test.tsx
@@ -41,6 +41,7 @@ describe("FocusPage", () => {
     expect(screen.getByLabelText("Minutes")).toBeTruthy();
     await user.click(screen.getByRole("button", { name: "Full screen" }));
     const stage = screen.getByRole("dialog", { name: "Timer" });
+    expect(stage.parentElement).toBe(document.body);
     expect(
       within(stage).getByRole("button", { name: "Play lo-fi" }),
     ).toBeTruthy();

--- a/front/src/components/FocusPage.tsx
+++ b/front/src/components/FocusPage.tsx
@@ -18,7 +18,7 @@ export default function FocusPage() {
 
   useEffect(() => {
     engine.current = new LofiEngine();
-    return () => engine.current?.stop();
+    return () => engine.current?.dispose();
   }, []);
 
   async function toggleMusic() {
@@ -32,7 +32,7 @@ export default function FocusPage() {
         return;
       }
       await player.start();
-      player.setAmbience(ambience);
+      await player.setAmbience(ambience);
       setPlaying(true);
     } catch {
       setAudioError("Could not start audio in this browser.");
@@ -41,7 +41,10 @@ export default function FocusPage() {
 
   function changeAmbience(kind: AmbienceKind) {
     setAmbience(kind);
-    engine.current?.setAmbience(kind);
+    setAudioError(null);
+    void engine.current?.setAmbience(kind).catch(() => {
+      setAudioError("Could not start audio in this browser.");
+    });
   }
 
   return (

--- a/front/src/components/TasksPage.tsx
+++ b/front/src/components/TasksPage.tsx
@@ -208,7 +208,7 @@ export default function TasksPage({ refreshKey, onChanged }: TasksPageProps) {
             <button
               type="button"
               onClick={undoRemove}
-              className="min-h-6 px-1 text-xs text-violet-300 hover:text-violet-200"
+              className="min-h-11 min-w-11 px-2 text-xs text-violet-300 hover:text-violet-200"
             >
               Undo
             </button>
@@ -244,7 +244,7 @@ export default function TasksPage({ refreshKey, onChanged }: TasksPageProps) {
             onChange={(event) => setTitle(event.target.value)}
             placeholder="Add a task"
             maxLength={200}
-            className="min-h-11 min-w-0 rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2 text-base text-neutral-100 outline-none placeholder:text-neutral-600 focus:border-neutral-600 sm:min-h-0 sm:text-sm"
+            className="min-h-11 min-w-0 rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2 text-base text-neutral-100 outline-none placeholder:text-neutral-600 focus:border-neutral-600 sm:text-sm"
           />
           <label htmlFor="new-task-date" className="sr-only">
             Due
@@ -254,7 +254,7 @@ export default function TasksPage({ refreshKey, onChanged }: TasksPageProps) {
             type="date"
             value={dueDate}
             onChange={(event) => setDueDate(event.target.value)}
-            className="min-h-11 rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2 text-base text-neutral-300 outline-none focus:border-neutral-600 sm:min-h-0 sm:text-sm"
+            className="min-h-11 rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2 text-base text-neutral-300 outline-none focus:border-neutral-600 sm:text-sm"
           />
           <button
             type="submit"
@@ -297,7 +297,7 @@ function TaskRow({
   onRemove: () => void;
 }) {
   return (
-    <div className="flex items-center gap-3 py-3">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2 py-3 sm:flex-nowrap">
       <input
         type="checkbox"
         checked={task.is_completed}
@@ -314,24 +314,26 @@ function TaskRow({
       >
         {task.title}
       </span>
-      <label className="sr-only" htmlFor={`task-due-${task.id}`}>
-        Due {task.title}
-      </label>
-      <input
-        id={`task-due-${task.id}`}
-        type="date"
-        value={task.due_date ?? ""}
-        onChange={(event) => onDueChange(event.target.value)}
-        className="w-[9.5rem] rounded-lg border border-neutral-800 bg-neutral-900 px-2 py-1.5 text-xs text-neutral-400 outline-none focus:border-neutral-600"
-      />
-      <button
-        type="button"
-        onClick={onRemove}
-        aria-label={`Remove ${task.title}`}
-        className="text-xs text-neutral-500 hover:text-neutral-200"
-      >
-        Remove
-      </button>
+      <div className="flex w-full min-w-0 items-center gap-2 sm:w-auto">
+        <label className="sr-only" htmlFor={`task-due-${task.id}`}>
+          Due {task.title}
+        </label>
+        <input
+          id={`task-due-${task.id}`}
+          type="date"
+          value={task.due_date ?? ""}
+          onChange={(event) => onDueChange(event.target.value)}
+          className="min-h-11 min-w-0 flex-1 rounded-lg border border-neutral-800 bg-neutral-900 px-2 py-1.5 text-base text-neutral-400 outline-none focus:border-neutral-600 sm:w-[9.5rem] sm:flex-none"
+        />
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`Remove ${task.title}`}
+          className="min-h-11 shrink-0 px-2 text-xs text-neutral-500 hover:text-neutral-200"
+        >
+          Remove
+        </button>
+      </div>
     </div>
   );
 }

--- a/front/src/focus/PomodoroTimer.tsx
+++ b/front/src/focus/PomodoroTimer.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import { createPortal } from "react-dom";
 
 import { AMBIENCE_OPTIONS, type AmbienceKind } from "./lofi";
 import StudyScene from "./StudyScene";
@@ -10,6 +17,23 @@ const NUDGE = 16;
 type TimerKind = "pomodoro" | "timer";
 type Point = { x: number; y: number };
 
+type StageInset = { top: number; right: number; bottom: number; left: number };
+
+function readPx(styles: CSSStyleDeclaration, name: string) {
+  const value = parseFloat(styles.getPropertyValue(name));
+  return Number.isFinite(value) ? value : 0;
+}
+
+function stageInset(stage: HTMLElement): StageInset {
+  const styles = getComputedStyle(stage);
+  return {
+    top: EDGE + readPx(styles, "--timer-safe-top"),
+    right: EDGE + readPx(styles, "--timer-safe-right"),
+    bottom: EDGE + readPx(styles, "--timer-safe-bottom"),
+    left: EDGE + readPx(styles, "--timer-safe-left"),
+  };
+}
+
 function clampPanel(
   x: number,
   y: number,
@@ -17,18 +41,24 @@ function clampPanel(
   panelH: number,
   stageW: number,
   stageH: number,
+  inset: StageInset = {
+    top: EDGE,
+    right: EDGE,
+    bottom: EDGE,
+    left: EDGE,
+  },
 ): Point {
-  const maxX = stageW - panelW - EDGE;
-  const maxY = stageH - panelH - EDGE;
+  const maxX = stageW - panelW - inset.right;
+  const maxY = stageH - panelH - inset.bottom;
   return {
     x:
-      maxX < EDGE
+      maxX < inset.left
         ? Math.max(0, (stageW - panelW) / 2)
-        : Math.min(maxX, Math.max(EDGE, x)),
+        : Math.min(maxX, Math.max(inset.left, x)),
     y:
-      maxY < EDGE
+      maxY < inset.top
         ? Math.max(0, (stageH - panelH) / 2)
-        : Math.min(maxY, Math.max(EDGE, y)),
+        : Math.min(maxY, Math.max(inset.top, y)),
   };
 }
 
@@ -221,30 +251,49 @@ export default function PomodoroTimer({
   }, [expanded]);
 
   useEffect(() => {
-    if (!expanded) {
-      dragRef.current = null;
-      setDragging(false);
-    }
+    if (!expanded) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
   }, [expanded]);
 
   useEffect(() => {
+    if (!expanded) {
+      dragRef.current = null;
+      setDragging(false);
+      setPos(null);
+    }
+  }, [expanded]);
+
+  useLayoutEffect(() => {
     if (!expanded) return;
-    function onResize() {
+    function place(forceCenter: boolean) {
       const stage = stageRef.current;
       const panel = panelRef.current;
       if (!stage || !panel) return;
       const bounds = stage.getBoundingClientRect();
-      setPos((current) => {
-        if (!current) return current;
-        return clampPanel(
-          current.x,
-          current.y,
+      const inset = stageInset(stage);
+      setPos((current) =>
+        clampPanel(
+          forceCenter || !current
+            ? (bounds.width - panel.offsetWidth) / 2
+            : current.x,
+          forceCenter || !current
+            ? (bounds.height - panel.offsetHeight) / 2
+            : current.y,
           panel.offsetWidth,
           panel.offsetHeight,
           bounds.width,
           bounds.height,
-        );
-      });
+          inset,
+        ),
+      );
+    }
+    place(true);
+    function onResize() {
+      place(false);
     }
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
@@ -316,6 +365,7 @@ export default function PomodoroTimer({
         panel.offsetHeight,
         bounds.width,
         bounds.height,
+        stageInset(stage),
       ),
     );
   }
@@ -393,6 +443,7 @@ export default function PomodoroTimer({
         panel.offsetHeight,
         bounds.width,
         bounds.height,
+        stageInset(stage),
       ),
     );
   }
@@ -527,15 +578,20 @@ export default function PomodoroTimer({
         </p>
         {renderControls()}
       </div>
-      {expanded && (
-        <div
-          ref={stageRef}
-          className="cadence-timer-stage"
-          role="dialog"
-          aria-label="Timer"
-        >
+      {expanded &&
+        createPortal(
           <div
-            className={dragging ? "pointer-events-none" : undefined}
+            ref={stageRef}
+            className="cadence-timer-stage"
+            role="dialog"
+            aria-label="Timer"
+          >
+          <div
+            className={
+              dragging
+                ? "pointer-events-none absolute inset-0"
+                : "absolute inset-0"
+            }
           >
             <StudyScene
               variant="stage"
@@ -632,7 +688,8 @@ export default function PomodoroTimer({
               {audioError ?? "\u00a0"}
             </p>
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
     </>
   );

--- a/front/src/focus/StudyScene.tsx
+++ b/front/src/focus/StudyScene.tsx
@@ -30,10 +30,8 @@ export default function StudyScene({
           src={cat.src}
           alt={photoIndex === index ? cat.alt : ""}
           className={[
-            "cadence-scene-crossfade absolute inset-0 h-full w-full object-cover",
-            photoIndex === index
-              ? "cadence-scene-drift opacity-100"
-              : "opacity-0",
+            "cadence-scene-crossfade cadence-scene-drift absolute inset-0 h-full w-full object-cover",
+            photoIndex === index ? "z-[1] opacity-100" : "z-0 opacity-0",
           ].join(" ")}
         />
       ))}

--- a/front/src/focus/lofi.ts
+++ b/front/src/focus/lofi.ts
@@ -19,21 +19,23 @@ export const AMBIENCE_OPTIONS: Array<{
 ];
 
 const AMBIENCE_LEVELS: Record<Exclude<AmbienceKind, "off">, number> = {
-  brown: 0.05,
-  white: 0.014,
-  rain: 0.03,
-  train: 0.04,
-  airplane: 0.038,
+  brown: 0.14,
+  white: 0.08,
+  rain: 0.16,
+  train: 0.14,
+  airplane: 0.14,
 };
 
 export class LofiEngine {
   private ctx: AudioContext | null = null;
   private master: GainNode | null = null;
+  private compressor: DynamicsCompressorNode | null = null;
   private music: GainNode | null = null;
   private ambienceGains = new Map<Exclude<AmbienceKind, "off">, GainNode>();
   private ambienceKind: AmbienceKind = "off";
   private timer: number | null = null;
-  private voices: AudioScheduledSourceNode[] = [];
+  private musicVoices: AudioScheduledSourceNode[] = [];
+  private ambienceVoices: AudioScheduledSourceNode[] = [];
   private playing = false;
   private nextTime = 0;
   private step = 0;
@@ -54,7 +56,77 @@ export class LofiEngine {
   }
 
   async start() {
+    await this.ensureContext();
     if (this.playing) return;
+    const ctx = this.ctx;
+    const compressor = this.compressor;
+    const master = this.master;
+    if (!ctx || !compressor || !master) return;
+
+    const music = ctx.createGain();
+    music.gain.value = 1;
+    music.connect(compressor);
+    this.connectDelay(ctx, music, master);
+    this.music = music;
+    this.playing = true;
+    this.step = 0;
+    this.nextTime = ctx.currentTime + 0.06;
+    this.vinyl(ctx, music);
+    this.schedule();
+  }
+
+  async setAmbience(kind: AmbienceKind) {
+    this.ambienceKind = kind;
+    if (kind === "off") {
+      this.applyAmbience();
+      if (!this.playing) this.dispose();
+      return;
+    }
+    await this.ensureContext();
+    this.applyAmbience();
+  }
+
+  stop() {
+    this.playing = false;
+    if (this.timer != null) {
+      window.clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.stopVoices(this.musicVoices);
+    this.musicVoices = [];
+    this.music?.disconnect();
+    this.music = null;
+    if (this.ambienceKind === "off") this.dispose();
+  }
+
+  dispose() {
+    this.playing = false;
+    if (this.timer != null) {
+      window.clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.stopVoices(this.musicVoices);
+    this.stopVoices(this.ambienceVoices);
+    this.musicVoices = [];
+    this.ambienceVoices = [];
+    this.ambienceGains.clear();
+    this.master?.disconnect();
+    this.master = null;
+    this.music = null;
+    this.compressor = null;
+    const ctx = this.ctx;
+    this.ctx = null;
+    if (ctx && ctx.state !== "closed") {
+      void ctx.close();
+    }
+  }
+
+  private async ensureContext() {
+    if (typeof AudioContext === "undefined") return;
+    if (this.ctx) {
+      if (this.ctx.state === "suspended") await this.ctx.resume();
+      return;
+    }
     const ctx = new AudioContext();
     this.ctx = ctx;
     await ctx.resume();
@@ -69,52 +141,10 @@ export class LofiEngine {
     compressor.release.value = 0.25;
     compressor.connect(master);
     master.connect(ctx.destination);
-
-    const music = ctx.createGain();
-    music.gain.value = 1;
-    music.connect(compressor);
-    this.connectDelay(ctx, music, master);
-
     this.master = master;
-    this.music = music;
-    this.playing = true;
-    this.step = 0;
-    this.nextTime = ctx.currentTime + 0.06;
-
-    this.vinyl(ctx, master);
+    this.compressor = compressor;
     this.buildAmbience(ctx, master);
     this.applyAmbience();
-    this.schedule();
-  }
-
-  setAmbience(kind: AmbienceKind) {
-    this.ambienceKind = kind;
-    this.applyAmbience();
-  }
-
-  stop() {
-    this.playing = false;
-    if (this.timer != null) {
-      window.clearTimeout(this.timer);
-      this.timer = null;
-    }
-    for (const voice of this.voices) {
-      try {
-        voice.stop();
-      } catch {
-        // already stopped
-      }
-    }
-    this.voices = [];
-    this.master?.disconnect();
-    this.master = null;
-    this.music = null;
-    this.ambienceGains.clear();
-    const ctx = this.ctx;
-    this.ctx = null;
-    if (ctx && ctx.state !== "closed") {
-      void ctx.close();
-    }
   }
 
   private connectDelay(ctx: AudioContext, source: AudioNode, dest: AudioNode) {
@@ -190,9 +220,23 @@ export class LofiEngine {
     }
   }
 
-  private track<T extends AudioScheduledSourceNode>(source: T): T {
-    this.voices.push(source);
+  private track<T extends AudioScheduledSourceNode>(
+    source: T,
+    group: "music" | "ambience" = "music",
+  ): T {
+    if (group === "ambience") this.ambienceVoices.push(source);
+    else this.musicVoices.push(source);
     return source;
+  }
+
+  private stopVoices(voices: AudioScheduledSourceNode[]) {
+    for (const voice of voices) {
+      try {
+        voice.stop();
+      } catch {
+        // already stopped
+      }
+    }
   }
 
   private noiseBuffer(ctx: AudioContext, seconds: number, pink: boolean) {
@@ -406,7 +450,7 @@ export class LofiEngine {
   }
 
   private brownBed(ctx: AudioContext, dest: AudioNode) {
-    const source = this.track(ctx.createBufferSource());
+    const source = this.track(ctx.createBufferSource(), "ambience");
     source.buffer = this.brownBuffer(ctx, 2.5);
     source.loop = true;
     const low = ctx.createBiquadFilter();
@@ -418,7 +462,7 @@ export class LofiEngine {
   }
 
   private whiteBed(ctx: AudioContext, dest: AudioNode) {
-    const source = this.track(ctx.createBufferSource());
+    const source = this.track(ctx.createBufferSource(), "ambience");
     source.buffer = this.noiseBuffer(ctx, 2, false);
     source.loop = true;
     const low = ctx.createBiquadFilter();
@@ -430,15 +474,15 @@ export class LofiEngine {
   }
 
   private rainBed(ctx: AudioContext, dest: AudioNode) {
-    const source = this.track(ctx.createBufferSource());
+    const source = this.track(ctx.createBufferSource(), "ambience");
     source.buffer = this.noiseBuffer(ctx, 2, true);
     source.loop = true;
     const high = ctx.createBiquadFilter();
     high.type = "highpass";
-    high.frequency.value = 5000;
+    high.frequency.value = 800;
     const low = ctx.createBiquadFilter();
     low.type = "lowpass";
-    low.frequency.value = 11000;
+    low.frequency.value = 8000;
     source.connect(high);
     high.connect(low);
     low.connect(dest);
@@ -446,7 +490,7 @@ export class LofiEngine {
   }
 
   private trainBed(ctx: AudioContext, dest: AudioNode) {
-    const rumble = this.track(ctx.createBufferSource());
+    const rumble = this.track(ctx.createBufferSource(), "ambience");
     rumble.buffer = this.brownBuffer(ctx, 2.5);
     rumble.loop = true;
     const rumbleFilter = ctx.createBiquadFilter();
@@ -459,7 +503,7 @@ export class LofiEngine {
     rumbleGain.connect(dest);
     rumble.start();
 
-    const clacks = this.track(ctx.createBufferSource());
+    const clacks = this.track(ctx.createBufferSource(), "ambience");
     clacks.buffer = this.trainClackBuffer(ctx);
     clacks.loop = true;
     const clackFilter = ctx.createBiquadFilter();
@@ -475,7 +519,7 @@ export class LofiEngine {
   }
 
   private airplaneBed(ctx: AudioContext, dest: AudioNode) {
-    const engines = this.track(ctx.createBufferSource());
+    const engines = this.track(ctx.createBufferSource(), "ambience");
     engines.buffer = this.brownBuffer(ctx, 3);
     engines.loop = true;
     const engineFilter = ctx.createBiquadFilter();
@@ -488,7 +532,7 @@ export class LofiEngine {
     engineGain.connect(dest);
     engines.start();
 
-    const cabin = this.track(ctx.createBufferSource());
+    const cabin = this.track(ctx.createBufferSource(), "ambience");
     cabin.buffer = this.noiseBuffer(ctx, 2, true);
     cabin.loop = true;
     const cabinHigh = ctx.createBiquadFilter();

--- a/front/src/focus/scenes.ts
+++ b/front/src/focus/scenes.ts
@@ -48,7 +48,7 @@ export function useStudyScene() {
     if (reduced) return;
     const id = window.setInterval(() => {
       setIndex((current) => (current + 1) % STUDY_SCENES.length);
-    }, 14000);
+    }, 24000);
     return () => window.clearInterval(id);
   }, []);
 

--- a/front/src/styles/base.css
+++ b/front/src/styles/base.css
@@ -213,7 +213,7 @@ html.dark body::before {
   touch-action: manipulation;
 }
 
-@media (min-width: 640px) {
+@media (min-width: 640px) and (hover: hover) and (pointer: fine) {
   .cadence-chip {
     min-height: 0;
     padding: 0.35rem 0.7rem;
@@ -232,7 +232,7 @@ html.dark body::before {
   padding: 0;
 }
 
-@media (min-width: 640px) {
+@media (min-width: 640px) and (hover: hover) and (pointer: fine) {
   .cadence-chip-icon {
     width: 2.15rem;
     min-height: 2.15rem;
@@ -262,7 +262,8 @@ html.dark select.cadence-chip-select {
 }
 
 select.cadence-chip-select-wide {
-  min-width: 11.75rem;
+  min-width: min(11.75rem, 100%);
+  max-width: 100%;
 }
 
 .cadence-chip-count {
@@ -281,7 +282,13 @@ select.cadence-chip-select-wide {
   position: fixed;
   inset: 0;
   z-index: 80;
+  overflow: hidden;
+  overscroll-behavior: none;
   background: var(--n-950);
+  --timer-safe-top: env(safe-area-inset-top, 0px);
+  --timer-safe-right: env(safe-area-inset-right, 0px);
+  --timer-safe-bottom: env(safe-area-inset-bottom, 0px);
+  --timer-safe-left: env(safe-area-inset-left, 0px);
 }
 
 .cadence-timer-float {
@@ -289,18 +296,31 @@ select.cadence-chip-select-wide {
   z-index: 1;
   box-sizing: border-box;
   width: 28rem;
-  max-width: calc(100vw - 2rem);
+  max-width: calc(100% - 2rem);
+  max-height: calc(
+    100% - 2rem - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)
+  );
+  overflow-x: hidden;
+  overflow-y: auto;
   border-radius: 1.35rem;
   background: color-mix(in srgb, var(--n-950) 58%, transparent);
   padding: 1.25rem 1.4rem 1.35rem;
   box-shadow: var(--shadow-page);
   backdrop-filter: blur(10px);
-  touch-action: none;
   user-select: none;
   cursor: grab;
 }
 
-.cadence-timer-float .cadence-chip-select {
+.cadence-timer-float .cadence-chip {
+  min-height: 2.75rem;
+}
+
+.cadence-timer-float .cadence-chip-icon {
+  width: 2.75rem;
+  min-height: 2.75rem;
+}
+
+.cadence-timer-float .cadence-chip-select:not(.cadence-chip-select-wide) {
   min-width: 8rem;
 }
 
@@ -329,6 +349,7 @@ select.cadence-chip-select-wide {
 
 .cadence-timer-float-dragging {
   cursor: grabbing;
+  touch-action: none;
 }
 
 .cadence-timer-drag {
@@ -343,16 +364,16 @@ select.cadence-chip-select-wide {
 
 @media (prefers-reduced-motion: no-preference) {
   .cadence-scene-drift {
-    animation: cadence-scene-drift 18s var(--ease-out) alternate infinite;
+    animation: cadence-scene-drift 40s ease-in-out alternate infinite;
   }
 }
 
 @keyframes cadence-scene-drift {
   from {
-    transform: scale(1);
+    transform: scale(1.03);
   }
   to {
-    transform: scale(1.07);
+    transform: scale(1.08);
   }
 }
 
@@ -366,13 +387,19 @@ summary {
   touch-action: manipulation;
 }
 
-button,
-summary {
-  min-height: 1.5rem;
-}
+@layer base {
+  button,
+  summary {
+    min-height: 1.5rem;
+  }
 
-button {
-  min-width: 1.5rem;
+  button {
+    min-width: 1.5rem;
+  }
+
+  label:has(> input[type="checkbox"]) {
+    min-height: 1.5rem;
+  }
 }
 
 summary {
@@ -386,10 +413,6 @@ textarea:focus-visible {
   outline-width: 2px;
   outline-color: var(--v-400);
   outline-offset: 2px;
-}
-
-label:has(> input[type="checkbox"]) {
-  min-height: 1.5rem;
 }
 
 button:disabled {
@@ -437,7 +460,7 @@ button:disabled {
 }
 
 .cadence-scene-crossfade {
-  transition: opacity 2.4s ease-in-out;
+  transition: opacity 6.5s cubic-bezier(0.37, 0, 0.63, 1);
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -460,11 +483,9 @@ button:disabled {
 @keyframes cadence-enter {
   from {
     opacity: 0;
-    transform: translateY(6px);
   }
   to {
     opacity: 1;
-    transform: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- Portal the Focus timer to the document so fullscreen covers the window instead of the tab column.
- Let background noise start without lo-fi, and keep scene crossfades slower so they do not flash.
- Make Tasks/Focus controls thumb-sized on phones, and keep the overlay inside the safe area.

## Test plan
- [x] Frontend unit tests
- [ ] Focus: Full screen covers the viewport; Exit works; rain plays with lo-fi paused
- [ ] Tasks: Remove/Undo/due date are easy to tap at phone width; no sideways scroll
- [ ] After deploy: `curl -fsS https://cadence.kanishq.dev/healthz`