### PR TITLE
Let fades occupy the time they claim, and fade the day dialog in

### DIFF
--- a/front/src/components/DashboardNav.tsx
+++ b/front/src/components/DashboardNav.tsx
@@ -60,7 +60,7 @@ export default function DashboardNav({
             className={
               view === item.id
                 ? "min-h-11 rounded-lg bg-neutral-800/80 px-2 text-sm text-neutral-100 sm:rounded-none sm:border-b sm:border-violet-400 sm:bg-transparent sm:px-0 sm:pb-1"
-                : "min-h-11 rounded-lg px-2 text-sm text-neutral-500 transition-colors duration-200 hover:text-neutral-200 sm:rounded-none sm:border-b sm:border-transparent sm:px-0 sm:pb-1"
+                : "min-h-11 rounded-lg px-2 text-sm text-neutral-500 transition-colors duration-150 hover:text-neutral-200 sm:rounded-none sm:border-b sm:border-transparent sm:px-0 sm:pb-1"
             }
           >
             {item.label}

--- a/front/src/components/DashboardPage.tsx
+++ b/front/src/components/DashboardPage.tsx
@@ -226,7 +226,7 @@ export default function DashboardPage() {
                 type="date"
                 value={selectedDate}
                 onChange={(event) => setSelectedDate(event.target.value)}
-                className="ml-2 min-h-11 rounded-lg border border-neutral-800 bg-neutral-900 px-2 py-2 text-base text-neutral-300 outline-none transition-colors duration-200 focus:border-neutral-600 sm:min-h-0 sm:py-1.5 sm:text-xs"
+                className="ml-2 min-h-11 rounded-lg border border-neutral-800 bg-neutral-900 px-2 py-2 text-base text-neutral-300 outline-none transition-colors duration-150 focus:border-neutral-600 sm:min-h-0 sm:py-1.5 sm:text-xs"
               />
             </label>
           </div>

--- a/front/src/components/DayHabitsDialog.tsx
+++ b/front/src/components/DayHabitsDialog.tsx
@@ -89,7 +89,7 @@ export default function DayHabitsDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-50/35 p-4"
+      className="cadence-overlay fixed inset-0 z-50 flex items-center justify-center bg-neutral-50/35 p-4"
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
@@ -100,7 +100,7 @@ export default function DayHabitsDialog({
         aria-modal="true"
         aria-labelledby={headingId}
         tabIndex={-1}
-        className="cadence-surface w-full max-w-sm outline-none"
+        className="cadence-dialog cadence-surface w-full max-w-sm outline-none"
       >
         <h2
           id={headingId}

--- a/front/src/components/GoalsSettings.tsx
+++ b/front/src/components/GoalsSettings.tsx
@@ -98,7 +98,7 @@ export default function GoalsSettings() {
           maxLength={200}
           className="min-w-0 rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 outline-none placeholder:text-neutral-600 focus:border-neutral-600"
         />
-        <button className="rounded-lg bg-neutral-800 px-3 py-2 text-xs text-neutral-200 transition-colors duration-200 hover:bg-neutral-700">
+        <button className="rounded-lg bg-neutral-800 px-3 py-2 text-xs text-neutral-200 transition-colors duration-150 hover:bg-neutral-700">
           Add
         </button>
       </form>
@@ -126,7 +126,7 @@ export default function GoalsSettings() {
                       <button
                         type="button"
                         onClick={() => void removeGoal(goal.id)}
-                        className="text-xs text-neutral-600 transition-colors duration-200 hover:text-red-400"
+                        className="text-xs text-neutral-600 transition-colors duration-150 hover:text-red-400"
                       >
                         Remove
                       </button>

--- a/front/src/components/HoursPage.tsx
+++ b/front/src/components/HoursPage.tsx
@@ -96,7 +96,7 @@ export default function HoursPage({
             type="date"
             value={date}
             onChange={(event) => onSelectDate(event.target.value)}
-            className="ml-2 min-h-11 rounded-lg border border-neutral-800 bg-neutral-900 px-2 py-2 text-base text-neutral-300 outline-none transition-colors duration-200 focus:border-neutral-600 sm:min-h-0 sm:py-1.5 sm:text-xs"
+            className="ml-2 min-h-11 rounded-lg border border-neutral-800 bg-neutral-900 px-2 py-2 text-base text-neutral-300 outline-none transition-colors duration-150 focus:border-neutral-600 sm:min-h-0 sm:py-1.5 sm:text-xs"
           />
         </label>
       </div>

--- a/front/src/components/daily/DailySummaryCard.tsx
+++ b/front/src/components/daily/DailySummaryCard.tsx
@@ -121,7 +121,7 @@ export default function DailySummaryCard({
           type="button"
           onClick={save}
           disabled={isLoading || isBusy}
-          className="rounded-lg bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 transition-colors duration-200 hover:bg-neutral-700 disabled:opacity-40"
+          className="rounded-lg bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 transition-colors duration-150 hover:bg-neutral-700 disabled:opacity-40"
         >
           Save review
         </button>

--- a/front/src/styles/base.css
+++ b/front/src/styles/base.css
@@ -32,9 +32,10 @@
   --habit-4: #b07a2c;
   --habit-5: #7a5a6e;
   --habit-6: #6b7344;
-  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-out: cubic-bezier(0.33, 0, 0.2, 1);
   --motion-ui: 280ms;
   --motion-micro: 180ms;
+  --motion-overlay: 200ms;
   --shadow-page:
     inset 0 1px 0 rgba(255, 255, 255, 0.62),
     0 1px 1px rgba(28, 25, 22, 0.04),
@@ -486,6 +487,20 @@ button:disabled {
   }
   to {
     opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .cadence-overlay,
+  .cadence-dialog {
+    animation: cadence-fade var(--motion-overlay) var(--ease-out) both;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cadence-overlay,
+  .cadence-dialog {
+    animation: cadence-fade var(--motion-micro) ease both;
   }
 }
 


### PR DESCRIPTION
> Rebased onto `main` after #38–#45 merged, and revised: #45 removed the `translateY` from `cadence-enter`, so an earlier version of this PR describing redistributed *travel* no longer applied. It is now about fade timing only, and the dialog is opacity-only to match the direction #45 took.

## What

Three motion changes. **No duration is increased and no new distance is travelled** — only timing, plus one transition added where there was none.

## 1. The shared easing front-loaded almost everything

`--ease-out` was `cubic-bezier(0.22, 1, 0.36, 1)`. Of a declared 280ms, **90% of the change landed in 105ms**; the remainder was imperceptible.

Since #45 made `cadence-enter` opacity-only, that curve now governs the page fade, the theme transition and `.cadence-fade`. A fade that resolves in 105ms reads as a cut, not a fade.

`cubic-bezier(0.33, 0, 0.2, 1)` spreads the same change over the same 280ms. Sampled per frame in the browser:

```
   31ms   opacity 0.057
   81ms   opacity 0.438
  147ms   opacity 0.828
  264ms   opacity 0.999

  90% at ~170ms  (was ~105ms)
```

Nothing got slower. The fade is now legible while it happens.

## 2. The day dialog had no transition at all

`DayHabitsDialog`'s backdrop is `fixed inset-0 … bg-neutral-50/35` with no transition, so opening it dimmed the entire viewport in a single frame — the most abrupt moment left in the app.

Backdrop and panel now fade together over 200ms:

```
time   backdrop   panel
  52ms    0.32      0.32
 101ms    0.79      0.79
 151ms    0.96      0.96
 202ms    1.00      1.00
```

Opacity only, no travel — consistent with #45 dropping the translate from `cadence-enter`, and the channel that avoids the optical flow associated with vestibular symptoms.

## 3. One value for hover feedback

Six stray `duration-200` colour transitions join the 31 already at `duration-150`.

## Accessibility

Verified at runtime in both states rather than by reading the CSS:

```
prefers-reduced-motion: no-preference
  dialog: overlay=cadence-fade 0.2s   panel=cadence-fade 0.2s
  focus scene drift: cadence-scene-drift 40s xinfinite

prefers-reduced-motion: reduce
  dialog: overlay=cadence-fade 0.18s  panel=cadence-fade 0.18s
  focus scene drift: none 0s x1        (disabled)
```

WCAG 2.3.3 *Animation from Interactions* stays satisfied, and durations stay under the ~400ms point where a system begins to be perceived as slow.

## Tested

- Per-frame sampling of the page fade and the dialog open, quoted above, against the built image on top of current `main`.
- Contrast and target-size audits across all seven views in both themes: unchanged — this touches timing only.
- `npm run typecheck` clean; `npx vitest run` 68 passed, no new failures.

<sub>Not changed here: the focus-room drift is auto-starting motion lasting over five seconds alongside other content. It is disabled under `prefers-reduced-motion`, but WCAG 2.2.2 *Pause, Stop, Hide* is more robustly met with an in-page control. Happy to add one.</sub>